### PR TITLE
Add pgsql configure to worker dockerfile

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install -y libpq-dev libzip-dev libjpeg-dev libpng-dev libwebp-dev libfreetype-dev libcurl4-openssl-dev libxml2-dev libonig-dev libssh2-1-dev supervisor openssh-client && \
     pecl install redis-6.0.2 ssh2-1.4.1 && \
     docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype && \
+    docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql && \
     docker-php-ext-install pdo_pgsql zip pcntl bcmath curl dom mbstring pdo_mysql mysqli && \
     docker-php-ext-install gd && \
     docker-php-ext-enable redis bcmath curl dom mbstring ssh2 && \


### PR DESCRIPTION
Functions such as `pg_connect` fail in the worker container otherwise, it seems - that's the only substantial PHP extension/config related difference between the two in any case (aside from the base container)